### PR TITLE
Add ResponseCache attribute for anti-caching

### DIFF
--- a/Controllers/AccesoController.cs
+++ b/Controllers/AccesoController.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace Proyecto_Final_Web.Controllers
 {
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     public class AccesoController : Controller
     {
         private readonly Logica_Usuarios _logicaUsuarios;

--- a/Controllers/GraficasController.cs
+++ b/Controllers/GraficasController.cs
@@ -8,7 +8,8 @@ using Newtonsoft.Json;
 
 namespace Proyecto_Final_Web.Controllers
 {
-    [Authorize(Roles = "Empleado,Administrador,Gerente")] 
+    [Authorize(Roles = "Empleado,Administrador,Gerente")]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     public class GraficasController : Controller
     {
         private readonly BDCanchasContext _context;

--- a/Controllers/ReportePDFController.cs
+++ b/Controllers/ReportePDFController.cs
@@ -7,6 +7,7 @@ using Rotativa.AspNetCore;
 namespace Proyecto_Final_Web.Controllers
 {
     [Authorize(Roles = "Empleado,Administrador,Gerente")]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     public class ReportePDFController : Controller
     {
         private readonly BDCanchasContext contexto;


### PR DESCRIPTION
## Summary
- apply `ResponseCache` attribute to `AccesoController`, `GraficasController`, and `ReportePDFController`
- ensure authentication protected controllers avoid caching sensitive content

## Testing
- `dotnet build -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cedd80fd4832b8220609054d9414c