### PR TITLE
Add cache control meta tags

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -3,6 +3,9 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <title>@ViewData["Title"] - Sistema de Reservas de Canchas</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />


### PR DESCRIPTION
## Summary
- add cache control meta tags in layout

## Testing
- `dotnet build Proyecto_Final_Web.sln`


------
https://chatgpt.com/codex/tasks/task_e_686cee5beb20832ba460f5752f46d9e9