### PR TITLE
Fix role checks for edit/delete visibility

### DIFF
--- a/Views/Canchas/Index.cshtml
+++ b/Views/Canchas/Index.cshtml
@@ -499,7 +499,7 @@
                                             </td>
                                             <td data-label="Acciones">
                                                 <div class="d-flex justify-content-center justify-content-md-start">
-                                                    @if (User.IsInRole("empleado") || User.IsInRole("administrador") || User.IsInRole("gerente"))
+                                                    @if (User.IsInRole("Empleado") || User.IsInRole("Administrador") || User.IsInRole("Gerente"))
                                                     {
                                                         <a asp-action="Edit" asp-route-id="@item.IdCancha" class="btn-action-edit">
                                                             <i class="fas fa-edit"></i> Editar

--- a/Views/EstadosFacturas/Index.cshtml
+++ b/Views/EstadosFacturas/Index.cshtml
@@ -421,7 +421,7 @@
                                             </td>
                                             <td data-label="Acciones">
                                                 <div class="d-flex justify-content-center justify-content-md-start">
-                                                    @if (User.IsInRole("empleado") || User.IsInRole("administrador") || User.IsInRole("gerente"))
+                                                    @if (User.IsInRole("Empleado") || User.IsInRole("Administrador") || User.IsInRole("Gerente"))
                                                     {
                                                         <a asp-action="Edit" asp-route-id="@item.IdEstadoFactura" class="btn-action-edit">
                                                             <i class="fas fa-edit"></i> Editar

--- a/Views/EstadosReservas/Index.cshtml
+++ b/Views/EstadosReservas/Index.cshtml
@@ -421,7 +421,7 @@
                                             </td>
                                             <td data-label="Acciones">
                                                 <div class="d-flex justify-content-center justify-content-md-start">
-                                                    @if (User.IsInRole("empleado") || User.IsInRole("administrador") || User.IsInRole("gerente"))
+                                                    @if (User.IsInRole("Empleado") || User.IsInRole("Administrador") || User.IsInRole("Gerente"))
                                                     {
                                                         <a asp-action="Edit" asp-route-id="@item.IdEstadoReserva" class="btn-action-edit">
                                                             <i class="fas fa-edit"></i> Editar

--- a/Views/Facturas/Index.cshtml
+++ b/Views/Facturas/Index.cshtml
@@ -486,7 +486,7 @@
                                             </td>
                                             <td data-label="Acciones">
                                                 <div class="d-flex justify-content-center justify-content-md-start">
-                                                    @if (User.IsInRole("empleado") || User.IsInRole("administrador") || User.IsInRole("gerente"))
+                                                    @if (User.IsInRole("Empleado") || User.IsInRole("Administrador") || User.IsInRole("Gerente"))
                                                     {
                                                         <a asp-action="Edit" asp-route-id="@item.IdFactura" class="btn-action-edit">
                                                             <i class="fas fa-edit"></i> Editar

--- a/Views/MetodosPagos/Index.cshtml
+++ b/Views/MetodosPagos/Index.cshtml
@@ -421,7 +421,7 @@
                                             </td>
                                             <td data-label="Acciones">
                                                 <div class="d-flex justify-content-center justify-content-md-start">
-                                                    @if (User.IsInRole("empleado") || User.IsInRole("administrador") || User.IsInRole("gerente"))
+                                                    @if (User.IsInRole("Empleado") || User.IsInRole("Administrador") || User.IsInRole("Gerente"))
                                                     {
                                                         <a asp-action="Edit" asp-route-id="@item.IdMetodoPago" class="btn-action-edit">
                                                             <i class="fas fa-edit"></i> Editar

--- a/Views/Reservas/Index.cshtml
+++ b/Views/Reservas/Index.cshtml
@@ -485,7 +485,7 @@
                                             </td>
                                             <td data-label="Acciones">
                                                 <div class="d-flex justify-content-center justify-content-md-start">
-                                                    @if (User.IsInRole("empleado") || User.IsInRole("administrador") || User.IsInRole("gerente"))
+                                                    @if (User.IsInRole("Empleado") || User.IsInRole("Administrador") || User.IsInRole("Gerente"))
                                                     {
                                                         <a asp-action="Edit" asp-route-id="@item.IdReserva" class="btn-action-edit">
                                                             <i class="fas fa-edit"></i> Editar

--- a/Views/Roles/Index.cshtml
+++ b/Views/Roles/Index.cshtml
@@ -434,7 +434,7 @@
                                             </td>
                                             <td data-label="Acciones">
                                                 <div class="d-flex justify-content-center justify-content-md-start">
-                                                    @if (User.IsInRole("gerente"))
+                                                    @if (User.IsInRole("Gerente"))
                                                     {
                                                         <a asp-action="Edit" asp-route-id="@item.IdRol" class="btn-action-edit">
                                                             <i class="fas fa-edit"></i> Editar

--- a/Views/Tarifas/Index.cshtml
+++ b/Views/Tarifas/Index.cshtml
@@ -499,7 +499,7 @@
                                             </td>
                                             <td data-label="Acciones">
                                                 <div class="d-flex justify-content-center justify-content-md-start">
-                                                    @if (User.IsInRole("empleado") || User.IsInRole("administrador") || User.IsInRole("gerente"))
+                                                    @if (User.IsInRole("Empleado") || User.IsInRole("Administrador") || User.IsInRole("Gerente"))
                                                     {
                                                         <a asp-action="Edit" asp-route-id="@item.IdTarifa" class="btn-action-edit">
                                                             <i class="fas fa-edit"></i> Editar

--- a/Views/Usuarios/Index.cshtml
+++ b/Views/Usuarios/Index.cshtml
@@ -491,15 +491,15 @@
                                                         var targetUserRole = item.IdRol;
 
                                                         bool canEditDelete = false;
-                                                        if (User.IsInRole("gerente"))
+                                                        if (User.IsInRole("Gerente"))
                                                         {
                                                             canEditDelete = true;
                                                         }
-                                                        else if (User.IsInRole("administrador") && targetUserRole >= 3) // Admin puede editar/eliminar Empleados y Clientes
+                                                        else if (User.IsInRole("Administrador") && targetUserRole >= 3) // Admin puede editar/eliminar Empleados y Clientes
                                                         {
                                                             canEditDelete = true;
                                                         }
-                                                        else if (User.IsInRole("empleado") && targetUserRole == 4) // Empleado solo puede editar/eliminar Clientes
+                                                        else if (User.IsInRole("Empleado") && targetUserRole == 4) // Empleado solo puede editar/eliminar Clientes
                                                         {
                                                             canEditDelete = true;
                                                         }


### PR DESCRIPTION
## Summary
- ensure role comparisons use consistent casing so authorized users can see edit and delete buttons

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cef8a245c832baf4ea6e5d6d16b73