### PR TITLE
Allow public client registration

### DIFF
--- a/Controllers/UsuariosController.cs
+++ b/Controllers/UsuariosController.cs
@@ -206,6 +206,39 @@ namespace Proyecto_Final_Web.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        // GET: Usuarios/Register
+        [AllowAnonymous]
+        public IActionResult Register()
+        {
+            ViewData["HideLayout"] = true;
+            ViewData["IsPublicRegister"] = true;
+            ViewData["IdRol"] = new SelectList(_context.Roles.Where(r => r.IdRol == 4), "IdRol", "Nombre");
+            var usuario = new Usuario { IdRol = 4 };
+            return View("Create", usuario);
+        }
+
+        // POST: Usuarios/Register
+        [HttpPost]
+        [AllowAnonymous]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Register([Bind("NombreCompleto,Correo,Contrasena,Telefono")] Usuario usuario)
+        {
+            ModelState.Remove("IdRolNavigation");
+            usuario.IdRol = 4;
+
+            if (ModelState.IsValid)
+            {
+                usuario.FechaRegistro = DateTime.Now;
+                _context.Add(usuario);
+                await _context.SaveChangesAsync();
+                return RedirectToAction("Index", "Acceso");
+            }
+            ViewData["HideLayout"] = true;
+            ViewData["IsPublicRegister"] = true;
+            ViewData["IdRol"] = new SelectList(_context.Roles.Where(r => r.IdRol == 4), "IdRol", "Nombre", usuario.IdRol);
+            return View("Create", usuario);
+        }
+
         private bool UsuarioExists(int id)
         {
             return _context.Usuarios.Any(e => e.IdUsuario == id);

--- a/Views/Acceso/Index.cshtml
+++ b/Views/Acceso/Index.cshtml
@@ -390,6 +390,9 @@
             <button type="submit" class="btn-submit">
                 <i class="fas fa-sign-in-alt me-2"></i> Ingresar
             </button>
+            <div class="text-center mt-3">
+                <a asp-controller="Usuarios" asp-action="Register">¿No tienes cuenta? Regístrate</a>
+            </div>
         </form>
     </div>
 

--- a/Views/Usuarios/Create.cshtml
+++ b/Views/Usuarios/Create.cshtml
@@ -1,7 +1,13 @@
-﻿@model Proyecto_Final_Web.Models.Usuario
+@model Proyecto_Final_Web.Models.Usuario
 
 @{
     ViewData["Title"] = "Create";
+    bool hideLayout = ViewData["HideLayout"] as bool? ?? false;
+    bool isPublicRegister = ViewData["IsPublicRegister"] as bool? ?? false;
+    if (hideLayout)
+    {
+        Layout = null;
+    }
 }
 
 <head>
@@ -545,7 +551,7 @@
                         <h4>Registra un nuevo usuario en el sistema</h4>
                     </div>
 
-                    <form asp-action="Create" method="post">
+                    <form asp-action="@(isPublicRegister ? "Register" : "Create")" method="post">
                         <div asp-validation-summary="ModelOnly" class="validation-summary text-danger">
                             <strong><i class="fas fa-exclamation-triangle"></i>Por favor corrige los siguientes errores:</strong>
                         </div>
@@ -553,9 +559,13 @@
                             <div class="form-grid">
                                 <div class="form-group">
                                     <label asp-for="IdRol" class="control-label">Rol</label>
-                                    <select asp-for="IdRol" class="form-control" asp-items="ViewBag.IdRol">
+                                    <select asp-for="IdRol" class="form-control" asp-items="ViewBag.IdRol" @(isPublicRegister ? "disabled" : "")>
                                         <option value="">-- Seleccione un Rol --</option>
                                     </select>
+                                    @if (isPublicRegister)
+                                    {
+                                        <input type="hidden" asp-for="IdRol" />
+                                    }
                                     <span asp-validation-for="IdRol" class="text-danger"></span>
                                 </div>
                                 <div class="form-group">
@@ -582,10 +592,20 @@
                         </div>
 
                         <div class="d-flex justify-content-between align-items-center mt-4">
-                            <a asp-action="Index" class="btn btn-outline-secondary back-link">
-                                <i class="fas fa-arrow-left me-2"></i>
-                                Volver al Listado
-                            </a>
+                            @if (isPublicRegister)
+                            {
+                                <a asp-controller="Acceso" asp-action="Index" class="btn btn-outline-secondary back-link">
+                                    <i class="fas fa-arrow-left me-2"></i>
+                                    Volver al Login
+                                </a>
+                            }
+                            else
+                            {
+                                <a asp-action="Index" class="btn btn-outline-secondary back-link">
+                                    <i class="fas fa-arrow-left me-2"></i>
+                                    Volver al Listado
+                                </a>
+                            }
 
                             <button type="submit" class="btn btn-primary">
                                 <i class="fas fa-save me-2"></i>


### PR DESCRIPTION
## Summary
- add `Register` action to `UsuariosController`
- hide layout when registering via login
- default role to Cliente and disable select
- link to registration from login page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf13c5328832baf1f06fe52187adf