### PR TITLE
Implement dynamic reservation price calculation

### DIFF
--- a/Controllers/CanchasController.cs
+++ b/Controllers/CanchasController.cs
@@ -21,6 +21,17 @@ namespace Proyecto_Final_Web.Controllers
             _context = context;
         }
 
+        [HttpGet]
+        public async Task<IActionResult> PrecioHora(int id)
+        {
+            var cancha = await _context.Canchas.FindAsync(id);
+            if (cancha == null)
+            {
+                return NotFound();
+            }
+            return Json(cancha.PrecioHora);
+        }
+
         // GET: Canchas
         public async Task<IActionResult> Index()
         {

--- a/Controllers/ReservasController.cs
+++ b/Controllers/ReservasController.cs
@@ -119,6 +119,16 @@ namespace Proyecto_Final_Web.Controllers
             if (ModelState.IsValid)
             {
                 reserva.FechaCreacion = DateTime.Now;
+                var cancha = await _context.Canchas.AsNoTracking().FirstOrDefaultAsync(c => c.IdCancha == reserva.IdCancha);
+                if (cancha != null)
+                {
+                    var horas = (reserva.FechaHoraFin - reserva.FechaHoraInicio).TotalHours;
+                    if (horas > 0)
+                    {
+                        reserva.Valor = Math.Round((decimal)horas * cancha.PrecioHora, 2);
+                    }
+                }
+
                 _context.Add(reserva);
                 await _context.SaveChangesAsync();
                 return RedirectToAction(nameof(Index));
@@ -223,6 +233,16 @@ namespace Proyecto_Final_Web.Controllers
             {
                 try
                 {
+                    var cancha = await _context.Canchas.AsNoTracking().FirstOrDefaultAsync(c => c.IdCancha == reserva.IdCancha);
+                    if (cancha != null)
+                    {
+                        var horas = (reserva.FechaHoraFin - reserva.FechaHoraInicio).TotalHours;
+                        if (horas > 0)
+                        {
+                            reserva.Valor = Math.Round((decimal)horas * cancha.PrecioHora, 2);
+                        }
+                    }
+
                     _context.Update(reserva);
                     await _context.SaveChangesAsync();
                     return RedirectToAction(nameof(Index));

--- a/Views/Reservas/Create.cshtml
+++ b/Views/Reservas/Create.cshtml
@@ -396,7 +396,7 @@
                                     @if (User.IsInRole("Cliente"))
                                     {
                                         <input asp-for="Valor" class="form-control" type="hidden" />
-                                        <input value="(Se calculará automáticamente)" class="form-control" readonly />
+                                        <input id="ValorDisplay" value="(Se calculará automáticamente)" class="form-control" readonly />
                                     }
                                     else
                                     {

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -9,3 +9,47 @@ window.addEventListener('pageshow', function (evt) {
     }
 });
 
+document.addEventListener('DOMContentLoaded', () => {
+    const canchaSelect = document.getElementById('IdCancha');
+    const inicioInput = document.getElementById('FechaHoraInicio');
+    const finInput = document.getElementById('FechaHoraFin');
+    const valorInput = document.getElementById('Valor');
+    const valorDisplay = document.getElementById('ValorDisplay');
+
+    async function obtenerPrecioHora(idCancha) {
+        if (!idCancha) return 0;
+        try {
+            const respuesta = await fetch(`/Canchas/PrecioHora?id=${idCancha}`);
+            if (!respuesta.ok) return 0;
+            return parseFloat(await respuesta.json());
+        } catch (e) {
+            console.error('Error obteniendo PrecioHora:', e);
+            return 0;
+        }
+    }
+
+    async function calcularValor() {
+        const idCancha = canchaSelect ? canchaSelect.value : null;
+        const inicio = inicioInput ? new Date(inicioInput.value) : null;
+        const fin = finInput ? new Date(finInput.value) : null;
+
+        if (!idCancha || isNaN(inicio) || isNaN(fin)) {
+            if (valorInput) valorInput.value = '';
+            if (valorDisplay) valorDisplay.value = '';
+            return;
+        }
+
+        const precioHora = await obtenerPrecioHora(idCancha);
+        const horas = (fin - inicio) / 3600000; // ms a horas
+        if (horas > 0 && precioHora >= 0) {
+            const total = (horas * precioHora).toFixed(2);
+            if (valorInput) valorInput.value = total;
+            if (valorDisplay) valorDisplay.value = total;
+        }
+    }
+
+    if (canchaSelect) canchaSelect.addEventListener('change', calcularValor);
+    if (inicioInput) inicioInput.addEventListener('change', calcularValor);
+    if (finInput) finInput.addEventListener('change', calcularValor);
+});
+


### PR DESCRIPTION
## Summary
- expose `Canchas/PrecioHora` endpoint
- recompute reservation value in Create/Edit actions
- show read-only price for clients
- auto-update value on client side via `site.js`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfb0f5ed0832b8902e7dc5616c82f