### PR TITLE
Update DB scripts and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Este proyecto utiliza una base de datos SQL Server local (LocalDB). Para evitar el error `Invalid column name 'PrecioHora'` asegúrese de que la tabla **Canchas** tenga la columna `PrecioHora`.
 
-Ejecute los scripts de base de datos incluidos en el repositorio para crear y poblar la base de datos. Si ya tiene una base existente y falta dicha columna, ejecute el script `SQLQuery_Actualizar_Canchas.sql`:
+Para inicializar la base de datos ejecute primero `SQLQuery_Crear_Tablas.sql` y luego `SQLQuery_Poblar_Tablas.sql`. Si la tabla **Canchas** ya existe y no contiene la columna `PrecioHora`, utilice `SQLQuery_Actualizar_Canchas.sql`:
 
 ```sql
 -- Agregar la columna PrecioHora si no existe
@@ -13,5 +13,5 @@ END
 GO
 ```
 
-Después de actualizar la base de datos, reinicie la aplicación y el error debería resolverse.
 
+Después de actualizar la base de datos, reinicie la aplicación y el error debería resolverse.

--- a/SQLQuery_Actualizar_Canchas.sql
+++ b/SQLQuery_Actualizar_Canchas.sql
@@ -1,0 +1,6 @@
+-- Agregar la columna PrecioHora si no existe
+IF COL_LENGTH('Canchas','PrecioHora') IS NULL
+BEGIN
+    ALTER TABLE [dbo].[Canchas] ADD [PrecioHora] DECIMAL(10,2) NOT NULL DEFAULT 0;
+END
+GO

--- a/SQLQuery_Crear_Tablas.sql
+++ b/SQLQuery_Crear_Tablas.sql
@@ -1,3 +1,6 @@
+USE [BDCanchas];
+GO
+
 ﻿-- Primero eliminamos las tablas en orden inverso a su creación (para evitar problemas de dependencias)
 IF OBJECT_ID('dbo.Facturas', 'U') IS NOT NULL
     DROP TABLE [dbo].[Facturas];

--- a/SQLQuery_Poblar_Tablas.sql
+++ b/SQLQuery_Poblar_Tablas.sql
@@ -1,3 +1,6 @@
+USE [BDCanchas];
+GO
+
 ﻿-- 1. Primero activar IDENTITY_INSERT para las tablas con columnas de identidad
 SET IDENTITY_INSERT [dbo].[Roles] ON;
 INSERT INTO [dbo].[Roles] ([IdRol], [Nombre], [Descripcion]) VALUES


### PR DESCRIPTION
## Summary
- add missing SQL script `SQLQuery_Actualizar_Canchas.sql`
- ensure table and data scripts select the BDCanchas database
- clarify usage instructions in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cff9d1b9c832ba6111ef13b7ea11a