### PR TITLE
Enable clients to specify reservation fields

### DIFF
--- a/Views/Reservas/Create.cshtml
+++ b/Views/Reservas/Create.cshtml
@@ -305,17 +305,9 @@
                                         <i class="fas fa-user text-primary"></i>
                                         Cliente
                                     </label>
-                                    @if (User.IsInRole("Cliente"))
-                                    {
-                                        <input asp-for="IdCliente" class="form-control" type="hidden" />
-                                        <input value="@User.FindFirst("NombreCompleto")?.Value" class="form-control" readonly />
-                                    }
-                                    else
-                                    {
-                                        <select asp-for="IdCliente" class="form-select" asp-items="ViewBag.IdCliente">
-                                            <option value="">🏃‍♂️ Seleccione Cliente</option>
-                                        </select>
-                                    }
+                                    <select asp-for="IdCliente" class="form-select" asp-items="ViewBag.IdCliente">
+                                        <option value="">🏃‍♂️ Seleccione Cliente</option>
+                                    </select>
                                 </div>
                             </div>
 
@@ -373,17 +365,9 @@
                                         <i class="fas fa-check-circle text-success"></i>
                                         Estado de la Reserva
                                     </label>
-                                    @if (User.IsInRole("Cliente"))
-                                    {
-                                        <input asp-for="IdEstadoReserva" class="form-control" type="hidden" />
-                                        <input value="Pre-reservado" class="form-control" readonly />
-                                    }
-                                    else
-                                    {
-                                        <select asp-for="IdEstadoReserva" class="form-select" asp-items="ViewBag.IdEstadoReserva">
-                                            <option value="">📋 Seleccione Estado</option>
-                                        </select>
-                                    }
+                                    <select asp-for="IdEstadoReserva" class="form-select" asp-items="ViewBag.IdEstadoReserva">
+                                        <option value="">📋 Seleccione Estado</option>
+                                    </select>
                                 </div>
                             </div>
 
@@ -393,20 +377,12 @@
                                         <i class="fas fa-dollar-sign text-success"></i>
                                         Valor de la Reserva
                                     </label>
-                                    @if (User.IsInRole("Cliente"))
-                                    {
-                                        <input asp-for="Valor" class="form-control" type="hidden" />
-                                        <input value="(Se calculará automáticamente)" class="form-control" readonly />
-                                    }
-                                    else
-                                    {
-                                        <div class="input-group">
-                                            <span class="input-group-text">
-                                                <i class="fas fa-money-bill-wave"></i>
-                                            </span>
-                                            <input asp-for="Valor" type="number" step="0.01" class="form-control" placeholder="0.00" />
-                                        </div>
-                                    }
+                                    <div class="input-group">
+                                        <span class="input-group-text">
+                                            <i class="fas fa-money-bill-wave"></i>
+                                        </span>
+                                        <input asp-for="Valor" type="number" step="0.01" class="form-control" placeholder="0.00" />
+                                    </div>
                                     <span asp-validation-for="Valor" class="text-danger"></span>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- allow any role to see selectable lists for clients and states when creating reservations
- let the Create action bind state and price and validate the selected client

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d12d4f3d8832b8a169d63a5f0d81d